### PR TITLE
Example Link.ToString just returns "Nancy.Hal.Link"

### DIFF
--- a/src/Nancy.Hal.Example/Program.cs
+++ b/src/Nancy.Hal.Example/Program.cs
@@ -15,6 +15,7 @@ namespace Nancy.Hal.Example
             using (var host = new NancyHost(new Uri("http://localhost:1234")))
             {
                 host.Start();
+                Console.WriteLine("Server running on http://localhost:1234");
                 Console.ReadLine();
             }
         }

--- a/src/Nancy.Hal/Link.cs
+++ b/src/Nancy.Hal/Link.cs
@@ -145,5 +145,10 @@ namespace Nancy.Hal
         {
             return !Equals(left, right);
         }
+
+        public override string ToString()
+        {                 
+            return string.Format("Rel={0}, Href={1}", Rel, Href);
+        }
     }
 }


### PR DESCRIPTION
Made the ToString, make more sense hopefully as it just showed "Nancy.Hal.Link"

I think Xamarin Studio has gone a bit nuts with the formatting too :worried: 