### PR TITLE
Predicated embeds

### DIFF
--- a/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
+++ b/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
@@ -126,6 +126,16 @@ namespace Nancy.Hal.Tests
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, (x, ctx) => x.Happy);
             Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pampered")[0][AdjustName("Type")]);
+
+            config = new HalConfiguration();
+            config.For<PetOwner>().
+                Embeds(owner => owner.Pets, x => x.Happy);
+            Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pets")[0][AdjustName("Type")]);
+
+            config = new HalConfiguration();
+            config.For<PetOwner>().
+                Embeds(owner => owner.Pets, (x, ctx) => x.Happy);
+            Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pets")[0][AdjustName("Type")]);
         }
 
         [Fact]
@@ -146,6 +156,16 @@ namespace Nancy.Hal.Tests
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, (x, ctx) => x.Happy);
             Assert.Null(GetData(Serialize(model, config), "_embedded", "pampered"));
+
+            config = new HalConfiguration();
+            config.For<PetOwner>().
+                Embeds(owner => owner.Pets, x => x.Happy);
+            Assert.Null(GetData(Serialize(model, config), "_embedded", "pets"));
+
+            config = new HalConfiguration();
+            config.For<PetOwner>().
+                Embeds(owner => owner.Pets, (x, ctx) => x.Happy);
+            Assert.Null(GetData(Serialize(model, config), "_embedded", "pets"));
         }
 
         [Fact]

--- a/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
+++ b/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
@@ -121,6 +121,11 @@ namespace Nancy.Hal.Tests
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, x => x.Happy);
             Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pampered")[0][AdjustName("Type")]);
+
+            config = new HalConfiguration();
+            config.For<PetOwner>().
+                Embeds("pampered", owner => owner.Pets, (x, ctx) => x.Happy);
+            Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pampered")[0][AdjustName("Type")]);
         }
 
         [Fact]
@@ -135,6 +140,11 @@ namespace Nancy.Hal.Tests
             var config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, x => x.Happy);
+            Assert.Null(GetData(Serialize(model, config), "_embedded", "pampered"));
+
+            config = new HalConfiguration();
+            config.For<PetOwner>().
+                Embeds("pampered", owner => owner.Pets, (x, ctx) => x.Happy);
             Assert.Null(GetData(Serialize(model, config), "_embedded", "pampered"));
         }
 

--- a/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
+++ b/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
@@ -120,6 +120,7 @@ namespace Nancy.Hal.Tests
             Action<PetOwner, HalConfiguration, string> assertPetIsCat = (owner, configuration, rel) =>
                 Assert.Equal("Cat", GetData(Serialize(owner, configuration), "_embedded", rel)[0][AdjustName("Type")]);
 
+
             var config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, x => x.Happy);
@@ -135,7 +136,6 @@ namespace Nancy.Hal.Tests
             config.For<PetOwner>().
                 Embeds(owner => owner.Pets, x => x.Happy);
             assertPetIsCat(model, config, "pets");
-
 
             config = new HalConfiguration();
             config.For<PetOwner>().
@@ -153,25 +153,31 @@ namespace Nancy.Hal.Tests
                 Pets = new[] { new Animal { Type = "Cat" } }
             };
 
+            Action<PetOwner, HalConfiguration, string> assertPetIsNull = (owner, configuration, rel) =>
+                Assert.Null(GetData(Serialize(owner, configuration), "_embedded", rel));
+
+
             var config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, x => x.Happy);
-            Assert.Null(GetData(Serialize(model, config), "_embedded", "pampered"));
+            assertPetIsNull(model, config, "pampered");
 
             config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, (x, ctx) => x.Happy);
-            Assert.Null(GetData(Serialize(model, config), "_embedded", "pampered"));
+            assertPetIsNull(model, config, "pampered");
+
 
             config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds(owner => owner.Pets, x => x.Happy);
-            Assert.Null(GetData(Serialize(model, config), "_embedded", "pets"));
+            assertPetIsNull(model, config, "pets");
 
             config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds(owner => owner.Pets, (x, ctx) => x.Happy);
-            Assert.Null(GetData(Serialize(model, config), "_embedded", "pets"));
+            assertPetIsNull(model, config, "pets");
+
         }
 
         [Fact]

--- a/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
+++ b/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
@@ -216,7 +216,7 @@ namespace Nancy.Hal.Tests
             };
             var json = Serialize(model, config, CreateTestContext(new { Operation = "Duck" }));
 
-            Assert.Null(json[this.AdjustName("Pets")]);
+            Assert.Null(json[AdjustName("Pets")]);
         }
 
         [Fact]

--- a/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
+++ b/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
@@ -117,25 +117,31 @@ namespace Nancy.Hal.Tests
                 Pets = new[] { new Animal { Type = "Cat" } }
             };
 
+            Action<PetOwner, HalConfiguration, string> assertPetIsCat = (owner, configuration, rel) =>
+                Assert.Equal("Cat", GetData(Serialize(owner, configuration), "_embedded", rel)[0][AdjustName("Type")]);
+
             var config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, x => x.Happy);
-            Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pampered")[0][AdjustName("Type")]);
+            assertPetIsCat(model, config, "pampered");
 
             config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds("pampered", owner => owner.Pets, (x, ctx) => x.Happy);
-            Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pampered")[0][AdjustName("Type")]);
+            assertPetIsCat(model, config, "pampered");
+
 
             config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds(owner => owner.Pets, x => x.Happy);
-            Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pets")[0][AdjustName("Type")]);
+            assertPetIsCat(model, config, "pets");
+
 
             config = new HalConfiguration();
             config.For<PetOwner>().
                 Embeds(owner => owner.Pets, (x, ctx) => x.Happy);
-            Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pets")[0][AdjustName("Type")]);
+            assertPetIsCat(model, config, "pets");
+
         }
 
         [Fact]

--- a/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
+++ b/src/Nancy.Hal.Tests/JsonResponseProcessorTests.cs
@@ -107,6 +107,36 @@ namespace Nancy.Hal.Tests
             Assert.Equal("Cat", GetData(json, "_embedded", "pampered")[0][AdjustName("Type")]);
             Assert.Equal("Chicken", GetStringValue(json, "_embedded", "liveStock", "Type"));
         }
+        
+        [Fact]
+        public void ShouldEmbedSubResourcesWhenPredicateIsTrue()
+        {
+            var model = new PetOwner
+            {
+                Happy = true,
+                Pets = new[] { new Animal { Type = "Cat" } }
+            };
+
+            var config = new HalConfiguration();
+            config.For<PetOwner>().
+                Embeds("pampered", owner => owner.Pets, x => x.Happy);
+            Assert.Equal("Cat", GetData(Serialize(model, config), "_embedded", "pampered")[0][AdjustName("Type")]);
+        }
+
+        [Fact]
+        public void ShouldNotEmbedSubResourcesWhenPredicateIsFalse()
+        {
+            var model = new PetOwner
+            {
+                Happy = false,
+                Pets = new[] { new Animal { Type = "Cat" } }
+            };
+
+            var config = new HalConfiguration();
+            config.For<PetOwner>().
+                Embeds("pampered", owner => owner.Pets, x => x.Happy);
+            Assert.Null(GetData(Serialize(model, config), "_embedded", "pampered"));
+        }
 
         [Fact]
         public void ShouldEmbedSubResourceProjections()

--- a/src/Nancy.Hal/Configuration/ConfigurationExtensions.cs
+++ b/src/Nancy.Hal/Configuration/ConfigurationExtensions.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Nancy.Hal.Configuration
 {

--- a/src/Nancy.Hal/Configuration/Extensions.cs
+++ b/src/Nancy.Hal/Configuration/Extensions.cs
@@ -1,6 +1,5 @@
 ﻿namespace Nancy.Hal.Configuration
 {
-    using System;
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Dynamic;
@@ -45,14 +44,14 @@
 
             protected override Expression VisitMember(MemberExpression node)
             {
-                this._found = node.Member as PropertyInfo;
+                _found = node.Member as PropertyInfo;
                 return base.VisitMember(node);
             }
 
             public PropertyInfo Find(Expression exp)
             {
-                this.Visit(exp);
-                return this._found;
+                Visit(exp);
+                return _found;
             }
         }
     }

--- a/src/Nancy.Hal/Configuration/HalConfiguration.cs
+++ b/src/Nancy.Hal/Configuration/HalConfiguration.cs
@@ -15,7 +15,7 @@ namespace Nancy.Hal.Configuration
 
         public IHalTypeConfiguration GetTypeConfiguration(Type type)
         {
-            IHalTypeConfiguration config = null;
+            IHalTypeConfiguration config;
             cache.TryGetValue(type, out config);
             return config;
         }

--- a/src/Nancy.Hal/Configuration/HalTypeConfiguration.cs
+++ b/src/Nancy.Hal/Configuration/HalTypeConfiguration.cs
@@ -148,6 +148,11 @@ namespace Nancy.Hal.Configuration
             return AddEmbeds(model => predicate(model) ? new EmbeddedResourceInfo<T>(rel, property.ExtractPropertyInfo().Name, property.Compile()) : null);
         }
 
+        public HalTypeConfiguration<T> Embeds(string rel, Expression<Func<T, dynamic>> property, Func<T, NancyContext, bool> predicate)
+        {
+            return AddEmbeds((model, ctx) => predicate(model, ctx) ? new EmbeddedResourceInfo<T>(rel, property.ExtractPropertyInfo().Name, property.Compile()) : null);
+        }
+
         public HalTypeConfiguration<T> Embeds(string rel, Expression<Func<T, dynamic>> property)
         {
             return AddEmbeds(new EmbeddedResourceInfo<T>(rel, property.ExtractPropertyInfo().Name, property.Compile()));

--- a/src/Nancy.Hal/Configuration/HalTypeConfiguration.cs
+++ b/src/Nancy.Hal/Configuration/HalTypeConfiguration.cs
@@ -143,6 +143,18 @@ namespace Nancy.Hal.Configuration
             return AddEmbeds(new EmbeddedResourceInfo<T>(propName.ToCamelCase(), propName, property.Compile()));
         }
 
+        public HalTypeConfiguration<T> Embeds(Expression<Func<T, dynamic>> property, Func<T, bool> predicate)
+        {
+            var propName = property.ExtractPropertyInfo().Name;
+            return AddEmbeds(model => predicate(model) ? new EmbeddedResourceInfo<T>(propName.ToCamelCase(), propName, property.Compile()) : null);
+        }
+
+        public HalTypeConfiguration<T> Embeds(Expression<Func<T, dynamic>> property, Func<T, NancyContext, bool> predicate)
+        {
+            var propName = property.ExtractPropertyInfo().Name;
+            return AddEmbeds((model, ctx) => predicate(model, ctx) ? new EmbeddedResourceInfo<T>(propName.ToCamelCase(), propName, property.Compile()) : null);
+        }
+
         public HalTypeConfiguration<T> Embeds(string rel, Expression<Func<T, dynamic>> property, Func<T, bool> predicate)
         {
             return AddEmbeds(model => predicate(model) ? new EmbeddedResourceInfo<T>(rel, property.ExtractPropertyInfo().Name, property.Compile()) : null);

--- a/src/Nancy.Hal/Configuration/HalTypeConfiguration.cs
+++ b/src/Nancy.Hal/Configuration/HalTypeConfiguration.cs
@@ -10,7 +10,7 @@ namespace Nancy.Hal.Configuration
     public interface IHalTypeConfiguration
     {
         IEnumerable<Link> LinksFor(object model, NancyContext context);
-        IEnumerable<IEmbeddedResourceInfo> Embedded();
+        IEnumerable<IEmbeddedResourceInfo> Embedded(object model, NancyContext context);
         IEnumerable<string> Ignored();
     }
 
@@ -28,9 +28,9 @@ namespace Nancy.Hal.Configuration
             return _delegates.SelectMany(c => c.LinksFor(model, context));
         }
 
-        public IEnumerable<IEmbeddedResourceInfo> Embedded()
+        public IEnumerable<IEmbeddedResourceInfo> Embedded(object model, NancyContext context)
         {
-            return _delegates.SelectMany(c => c.Embedded());
+            return _delegates.SelectMany(c => c.Embedded(model, context));
         }
 
         public IEnumerable<string> Ignored()
@@ -41,7 +41,7 @@ namespace Nancy.Hal.Configuration
 
     public class HalTypeConfiguration<T> : IHalTypeConfiguration
     {
-        private readonly IList<IEmbeddedResourceInfo> embedded = new List<IEmbeddedResourceInfo>();
+        private readonly IList<Func<T, NancyContext, IEmbeddedResourceInfo>> embedded = new List<Func<T, NancyContext, IEmbeddedResourceInfo>>();
         private readonly IList<Func<T, NancyContext, Link>> links = new List<Func<T, NancyContext, Link>>();
         private readonly IList<string> ignoredProperties = new List<string>();
         private readonly object syncRoot = new object();
@@ -52,9 +52,10 @@ namespace Nancy.Hal.Configuration
             return links.Select(x => x(model, context)).Where(x => x != null);
         }
 
-        public IEnumerable<IEmbeddedResourceInfo> Embedded()
+        public IEnumerable<IEmbeddedResourceInfo> Embedded(object obj, NancyContext context)
         {
-            return embedded;
+            var model = (T)obj;
+            return embedded.Select(x => x(model, context)).Where(x => x != null);
         }
 
         public IEnumerable<string> Ignored()
@@ -119,9 +120,19 @@ namespace Nancy.Hal.Configuration
 
         private HalTypeConfiguration<T> AddEmbeds(IEmbeddedResourceInfo embed)
         {
+            return AddEmbeds((model, context) => embed);
+        }
+
+        private HalTypeConfiguration<T> AddEmbeds(Func<T, IEmbeddedResourceInfo> predicate)
+        {
+            return AddEmbeds((model, context) => predicate(model));
+        }
+
+        private HalTypeConfiguration<T> AddEmbeds(Func<T, NancyContext, IEmbeddedResourceInfo> predicate)
+        {
             lock (syncRoot)
             {
-                embedded.Add(embed);
+                embedded.Add(predicate);
             }
             return this;
         }
@@ -130,6 +141,11 @@ namespace Nancy.Hal.Configuration
         {
             var propName = property.ExtractPropertyInfo().Name;
             return AddEmbeds(new EmbeddedResourceInfo<T>(propName.ToCamelCase(), propName, property.Compile()));
+        }
+
+        public HalTypeConfiguration<T> Embeds(string rel, Expression<Func<T, dynamic>> property, Func<T, bool> predicate)
+        {
+            return AddEmbeds(model => predicate(model) ? new EmbeddedResourceInfo<T>(rel, property.ExtractPropertyInfo().Name, property.Compile()) : null);
         }
 
         public HalTypeConfiguration<T> Embeds(string rel, Expression<Func<T, dynamic>> property)

--- a/src/Nancy.Hal/Configuration/HalTypeConfiguration.cs
+++ b/src/Nancy.Hal/Configuration/HalTypeConfiguration.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using Nancy.Extensions;
 
 namespace Nancy.Hal.Configuration
@@ -10,7 +9,7 @@ namespace Nancy.Hal.Configuration
     public interface IHalTypeConfiguration
     {
         IEnumerable<Link> LinksFor(object model, NancyContext context);
-        IEnumerable<IEmbeddedResourceInfo> Embedded(object model, NancyContext context);
+        IEnumerable<IEmbeddedResourceInfo> EmbedsFor(object model, NancyContext context);
         IEnumerable<string> Ignored();
     }
 
@@ -20,7 +19,7 @@ namespace Nancy.Hal.Configuration
 
         public AggregatingHalTypeConfiguration(IEnumerable<IHalTypeConfiguration> delegates)
         {
-            this._delegates = delegates.Where(el => el != null);
+            _delegates = delegates.Where(el => el != null);
         }
 
         public IEnumerable<Link> LinksFor(object model, NancyContext context)
@@ -28,9 +27,9 @@ namespace Nancy.Hal.Configuration
             return _delegates.SelectMany(c => c.LinksFor(model, context));
         }
 
-        public IEnumerable<IEmbeddedResourceInfo> Embedded(object model, NancyContext context)
+        public IEnumerable<IEmbeddedResourceInfo> EmbedsFor(object model, NancyContext context)
         {
-            return _delegates.SelectMany(c => c.Embedded(model, context));
+            return _delegates.SelectMany(c => c.EmbedsFor(model, context));
         }
 
         public IEnumerable<string> Ignored()
@@ -52,7 +51,7 @@ namespace Nancy.Hal.Configuration
             return links.Select(x => x(model, context)).Where(x => x != null);
         }
 
-        public IEnumerable<IEmbeddedResourceInfo> Embedded(object obj, NancyContext context)
+        public IEnumerable<IEmbeddedResourceInfo> EmbedsFor(object obj, NancyContext context)
         {
             var model = (T)obj;
             return embedded.Select(x => x(model, context)).Where(x => x != null);

--- a/src/Nancy.Hal/Processors/HalJsonResponseProcessor.cs
+++ b/src/Nancy.Hal/Processors/HalJsonResponseProcessor.cs
@@ -67,7 +67,7 @@ namespace Nancy.Hal.Processors
             if (links.Any())
                 halModel["_links"] = links.GroupBy(l => l.Rel).ToDictionary(grp => grp.Key, grp => BuildDynamicLinksOrLink(grp));
 
-            var embeddedResources = typeConfig.Embedded(model, context).ToArray();
+            var embeddedResources = typeConfig.EmbedsFor(model, context).ToArray();
             if (embeddedResources.Any())
             {
                 // Remove original objects from the model (if they exist)

--- a/src/Nancy.Hal/Processors/HalJsonResponseProcessor.cs
+++ b/src/Nancy.Hal/Processors/HalJsonResponseProcessor.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
-using Microsoft.JScript;
 using Nancy.Hal.Configuration;
 using Nancy.Responses;
 using Nancy.Responses.Negotiation;

--- a/src/Nancy.Hal/Processors/HalJsonResponseProcessor.cs
+++ b/src/Nancy.Hal/Processors/HalJsonResponseProcessor.cs
@@ -68,7 +68,7 @@ namespace Nancy.Hal.Processors
             if (links.Any())
                 halModel["_links"] = links.GroupBy(l => l.Rel).ToDictionary(grp => grp.Key, grp => BuildDynamicLinksOrLink(grp));
 
-            var embeddedResources = typeConfig.Embedded().ToArray();
+            var embeddedResources = typeConfig.Embedded(model, context).ToArray();
             if (embeddedResources.Any())
             {
                 // Remove original objects from the model (if they exist)


### PR DESCRIPTION
Hi,

I'd like to add the ability to conditionally embed a sub-resource.  To achieve this at present, the options  are to either have conditional logic surrounding the hal-configuration or always embed a resource but return null under certain conditions.  Both aren't ideal; the former becomes really messy whilst the later potentially leaks implementation details.

And so I've added overloads to the Embeds methods so that a predicate can be evaluated to determine whether not the sub-resource should be embedded.  It follows the pattern used to add Links.  

This disadvantage to this approach is that it's a breaking change to the IHalTypeConfiguration interface;  I've renamed Embedded to EmbedsFor and now pass in the model and context.

I've added unit tests but haven't updated the example (mostly because the given model doesn't allow for a good example).  

I'm not really sure of the etiquette here but hoping you'll accept the PR.  Let me know if there's anything else I can do.

Joe