### PR TITLE
corrections to render Title attributes for links.

### DIFF
--- a/src/Nancy.Hal.Example/ExampleBootstrapper.cs
+++ b/src/Nancy.Hal.Example/ExampleBootstrapper.cs
@@ -60,7 +60,7 @@ namespace Nancy.Hal.Example
             var config = new HalConfiguration();
 
             config.For<UserSummary>()
-                .Links(model => new Link("self", "/users/{id}").CreateLink(model));
+                .Links(model => new Link("self", "/users/{id}", "Info").CreateLink(model));
 
             config.For<PagedList<UserSummary>>()
                   .Embeds("users", x => x.Data)
@@ -69,18 +69,18 @@ namespace Nancy.Hal.Example
                       LinkTemplates.Users.GetUsersPaged.CreateLink("self", ctx.Request.Query, new { blah = "123" }))
                   .Links(
                       (model, ctx) =>
-                      LinkTemplates.Users.GetUsersPaged.CreateLink("next", ctx.Request.Query, new { page = model.PageNumber + 1 }),
+                      LinkTemplates.Users.GetUsersPaged.CreateLink("Next", "next", ctx.Request.Query, new { page = model.PageNumber + 1 }),
                       model => model.PageNumber < model.TotalPages)
                   .Links(
                       (model, ctx) =>
-                      LinkTemplates.Users.GetUsersPaged.CreateLink("prev", ctx.Request.Query, new { page = model.PageNumber - 1 }),
+                      LinkTemplates.Users.GetUsersPaged.CreateLink("Previous", "prev", ctx.Request.Query, new { page = model.PageNumber - 1 }),
                       model => model.PageNumber > 0);
 
 
             config.For<UserDetails>()
                   .Embeds("role", model => model.Role)
                   .Links(model => LinkTemplates.Users.GetUser.CreateLink("self", model))
-                  .Links(model => LinkTemplates.Users.GetUser.CreateLink("edit", model))
+                  .Links(model => LinkTemplates.Users.GetUser.CreateLink("Edit", "edit", model))
                   .Links(model => LinkTemplates.User.ChangeRole.CreateLink(model))
                   .Links(model => LinkTemplates.User.Deactivate.CreateLink(model), model => model.Active)
                   .Links(model => LinkTemplates.User.Reactivate.CreateLink(model), model => !model.Active);
@@ -93,8 +93,8 @@ namespace Nancy.Hal.Example
 
             config.For<RoleDetails>()
                   .Links(model => LinkTemplates.Roles.GetRole.CreateLink("self", model))
-                  .Links(model => LinkTemplates.Roles.GetRole.CreateLink("edit", model))
-                  .Links(model => LinkTemplates.Roles.GetRole.CreateLink("delete", model));
+                  .Links(model => LinkTemplates.Roles.GetRole.CreateLink("Edit", "edit", model))
+                  .Links(model => LinkTemplates.Roles.GetRole.CreateLink("Delete", "delete", model));
 
             return config;
         }

--- a/src/Nancy.Hal.Tests/LinkTests.cs
+++ b/src/Nancy.Hal.Tests/LinkTests.cs
@@ -1,0 +1,48 @@
+﻿using Xunit;
+
+namespace Nancy.Hal.Tests {
+	public class LinkTests {
+		[Fact]
+		public void A_link_can_be_created() {
+			var sut = new Link("self", "/some/uri", "some-title");
+			Assert.Equal(sut.Title, "some-title");
+			Assert.Equal(sut.Rel, "self");
+			Assert.Equal(sut.Href, "/some/uri");
+		}
+
+		[Fact]
+		public void A_templated_link_can_be_reated() {
+			var sut = new Link("self", "/some/uri/{id}", "some-title");
+			Assert.Equal(sut.Title, "some-title");
+			Assert.Equal(sut.Rel, "self");
+			Assert.Equal(sut.Href, "/some/uri/{id}");
+		}
+
+		[Fact]
+		public void Using_a_templated_link_should_copy_all_fields() {
+			var template = new Link("self", "/some/uri/{id}", "some-title");
+			var sut = template.CreateLink(new { id = 1 });
+			Assert.Equal(sut.Title, "some-title");
+			Assert.Equal(sut.Rel, "self");
+			Assert.Equal(sut.Href, "/some/uri/1");
+		}
+
+		[Fact]
+		public void Using_a_templated_link_with_a_new_rel_should_have_the_new_rel() {
+			var template = new Link("self", "/some/uri/{id}", "some-title");
+			var sut = template.CreateLink("myrel", new { id = 1 });
+			Assert.Equal(sut.Title, "some-title");
+			Assert.Equal(sut.Rel, "myrel");
+			Assert.Equal(sut.Href, "/some/uri/1");
+		}
+
+		[Fact]
+		public void Using_a_templated_link_a_new_link_should_be_able_to_be_generated_with_title_and_rel() {
+			var template = new Link("self", "/some/uri/{id}", "some-title");
+			var sut = template.CreateLink("My Title", "myrel", new { id = 1 });
+			Assert.Equal(sut.Title, "My Title");
+			Assert.Equal(sut.Rel, "myrel");
+			Assert.Equal(sut.Href, "/some/uri/1");
+		}
+	}
+}

--- a/src/Nancy.Hal.Tests/Nancy.Hal.Tests.csproj
+++ b/src/Nancy.Hal.Tests/Nancy.Hal.Tests.csproj
@@ -82,6 +82,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="JsonResponseProcessorTests.cs" />
+    <Compile Include="LinkTests.cs" />
     <Compile Include="MockTypeConfiguration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PetOwner.cs" />

--- a/src/Nancy.Hal/Link.cs
+++ b/src/Nancy.Hal/Link.cs
@@ -41,8 +41,22 @@ namespace Nancy.Hal
         /// <returns>A link with new rel</returns>
         public Link ChangeRel(string newRel)
         {
-            return new Link(newRel, Href);
+            return new Link(newRel, Href, Title);
         }
+
+		/// <summary>
+		/// If this link is templated, you can use this method to make a non-templated copy, providing a title.
+		/// </summary>
+		/// <param name="title">The title.</param>
+		/// <param name="newRel">The new relative.</param>
+		/// <param name="parameters">The parameters.</param>
+		/// <returns></returns>
+		public Link CreateLink(string title, string newRel, params object[] parameters) 
+		{
+			var lnk = ChangeRel(newRel).CreateLink(parameters);
+			lnk.Title = title;
+			return lnk;
+		}
 
         /// <summary>
         /// If this link is templated, you can use this method to make a non templated copy
@@ -62,7 +76,7 @@ namespace Nancy.Hal
         /// <returns>A non templated link</returns>
         public Link CreateLink(params object[] parameters)
         {
-            return IsTemplated ? new Link(Rel, CreateUri(parameters).ToString()) : this;
+            return IsTemplated ? new Link(Rel, CreateUri(parameters).ToString(), Title) : this;
         }
 
         private Uri CreateUri(params object[] parameters)


### PR DESCRIPTION
This allows the use case of being able to build templates, and then provide links from those templates with human readable titles.

e.g.

```C#
config.For<PagedList<UserSummary>>()
        .Embeds("users", x => x.Data)
        .Links(
            (model, ctx) =>
            LinkTemplates.Users.GetUsersPaged.CreateLink("self", ctx.Request.Query, new { blah = "123" }))
        .Links(
            (model, ctx) =>
            LinkTemplates.Users.GetUsersPaged.CreateLink("Next", "next", ctx.Request.Query, new { page = model.PageNumber + 1 }),
            model => model.PageNumber < model.TotalPages)
        .Links(
            (model, ctx) =>
            LinkTemplates.Users.GetUsersPaged.CreateLink("Previous", "prev", ctx.Request.Query, new { page = model.PageNumber - 1 }),
            model => model.PageNumber > 0);
```

Will provide `Next` and `Previous` in the `title` fields, so they can be rendered on buttons, links, etc.